### PR TITLE
remove absolute path

### DIFF
--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func convertFiles(videosChan <-chan string) {
 		}
 
 		logger.Printf("Running ffmpeg with arguments %v\n", commandArgs)
-		if err := exec.Command("/usr/bin/ffmpeg", commandArgs...).Run(); err != nil {
+		if err := exec.Command("ffmpeg", commandArgs...).Run(); err != nil {
 			logger.Println(err)
 			continue
 		}
@@ -172,7 +172,7 @@ func hasCodec(codec string, codecs []string) bool {
 	return false
 }
 
-// Gets a lit of codecs that are used by the video file
+// Gets a list of codecs that are used by the video file
 func getCodecs(filename string) ([]string, error) {
 	probeCommand := fmt.Sprintf("ffprobe -v error -show_format -show_streams \"%s\" | grep codec_name", filename)
 	output, err := exec.Command("/bin/sh", "-c", probeCommand).Output()


### PR DESCRIPTION
Hi simonjm:
when execute a command in go like `exec.Command("/usr/bin/ffmpeg", commandArgs...)`  we don't need to specify the absolute path of the executable file,  as the [GoDoc](https://golang.org/pkg/os/exec/#Command) says: If name contains no path separators, Command uses LookPath to resolve name to a complete path if possible. Otherwise it uses name directly as Path. 

since ffmpeg may not installed in `/usr/bin/ffmpeg` on various Linux Distributions, I think just use `ffmpeg` will be better.
